### PR TITLE
Sort BED file by chromosome and position after calculating breakpoints.

### DIFF
--- a/src/bcbio/variation/recall/split.clj
+++ b/src/bcbio/variation/recall/split.clj
@@ -26,7 +26,7 @@
   [fai-file region base-file]
   (let [region-file (region->bed region (fsp/add-file-part base-file "inputregion" nil ".bed"))]
     (str (<< "cut -f 1-2 ~{fai-file} | awk -F $'\\t' '{OFS=FS} {print $1,0,$2}'")
-         (if region-file (<< " | bedtools intersect -a stdin -b ~{region-file}") ""))))
+         (if region-file (<< " | bedtools intersect -a stdin -b ~{region-file} | sort -k1,1 -k2,2 -n") ""))))
 
 (defn- vcf-breakpoints
   "Prepare BED file of non-variant regions in the input VCF as parallel breakpoints.


### PR DESCRIPTION
I think vcf-breakpoints sometimes spits out non-sorted BED files.
