### PR TITLE
Fix logic for no regions specification.

### DIFF
--- a/src/bcbio/variation/recall/vcfutils.clj
+++ b/src/bcbio/variation/recall/vcfutils.clj
@@ -63,7 +63,7 @@
   "Convert a region specification to a bcftools option, handling chr1:1-100 and BED files"
   [region]
   (cond
-   (and (fs/file? region) (fs/exists? region)) (str "-R " region)
+   (and region (fs/file? region) (fs/exists? region)) (str "-R " region)
    region (str "-r " region)
    :else ""))
 


### PR DESCRIPTION
It was crashing on the file-exists? check if no regions were specified during squaring.
